### PR TITLE
Stringifies TGI params

### DIFF
--- a/services/css-inference/1.0.0/recipe.json
+++ b/services/css-inference/1.0.0/recipe.json
@@ -42,7 +42,7 @@
             "description": "The retry parameters as a stringified JSON object.",
             "type": "string",
             "required": false,
-            "default": "{\"retry_params\": {\"tries\": 3, \"delay\": 1, \"backoff\": 2, \"max_delay\": 10, \"jitter\": [0.5, 1.5]}}"
+            "default": "{\"tries\": 3, \"delay\": 1, \"backoff\": 2, \"max_delay\": 10, \"jitter\": [0.5, 1.5]}"
         },
         {
             "id": "NUM_WORKERS",

--- a/services/tgi-client-inference/1.0.0/README.md
+++ b/services/tgi-client-inference/1.0.0/README.md
@@ -17,6 +17,7 @@ To use this recipe, include the following in your `config.json` [containers](htt
         "TGI_SERVICE_URL": <your_value_here>,
         "HF_TOKEN": <your_value_here>,
         "CONNECTION_TIMEOUT": <your_value_here>,  // OPTIONAL
+        "RETRY_PARAMS": <your_value_here>,        // OPTIONAL
         "NUM_WORKERS": <your_value_here>,         // OPTIONAL
     }
 }

--- a/services/tgi-client-inference/1.0.0/README.md
+++ b/services/tgi-client-inference/1.0.0/README.md
@@ -17,7 +17,6 @@ To use this recipe, include the following in your `config.json` [containers](htt
         "TGI_SERVICE_URL": <your_value_here>,
         "HF_TOKEN": <your_value_here>,
         "CONNECTION_TIMEOUT": <your_value_here>,  // OPTIONAL
-        "RETRY_PARAMS": <your_value_here>,        // OPTIONAL
         "NUM_WORKERS": <your_value_here>,         // OPTIONAL
     }
 }

--- a/services/tgi-client-inference/1.0.0/recipe.json
+++ b/services/tgi-client-inference/1.0.0/recipe.json
@@ -40,6 +40,14 @@
             "default": 30
         },
         {
+            "id": "RETRY_PARAMS",
+            "path": "env.TGI_INF_WORKFLOW_KW_ARGS",
+            "description": "The retry parameters as a stringified JSON object.",
+            "type": "string",
+            "required": false,
+            "default": "{\"retry_params\": {\"tries\": 3, \"delay\": 1, \"backoff\": 2, \"max_delay\": 10, \"jitter\": [0.5, 1.5]}}"
+        },
+        {
             "id": "NUM_WORKERS",
             "path": "command#NUM_WORKERS",
             "description": "The number of workers to use with the server.",

--- a/services/tgi-client-inference/1.0.0/recipe.json
+++ b/services/tgi-client-inference/1.0.0/recipe.json
@@ -5,13 +5,7 @@
         "description": "TGI Client Inference Service",
         "command": "--bind=0.0.0.0:3000 --workers=${NUM_WORKERS}",
         "env": {
-            "TGI_INF_WORKFLOW_POSITIONAL_ARGS": [
-                "${TGI_SERVICE_URL}",
-                "${CONNECTION_TIMEOUT}",
-                {
-                    "Authorization": "${HF_TOKEN}"
-                }
-            ]
+            "TGI_INF_WORKFLOW_POSITIONAL_ARGS": "[\"${TGI_SERVICE_URL}\", ${CONNECTION_TIMEOUT}, {\"Authorization\": \"Bearer ${HF_TOKEN}\"}]"
         },
         "external": true,
         "gpu": false,
@@ -44,14 +38,6 @@
             "type": "integer",
             "required": false,
             "default": 30
-        },
-        {
-            "id": "RETRY_PARAMS",
-            "path": "env.TGI_INF_WORKFLOW_KW_ARGS",
-            "description": "The retry parameters as a stringified JSON object.",
-            "type": "string",
-            "required": false,
-            "default": "{\"retry_params\": {\"tries\": 3, \"delay\": 1, \"backoff\": 2, \"max_delay\": 10, \"jitter\": [0.5, 1.5]}}"
         },
         {
             "id": "NUM_WORKERS",


### PR DESCRIPTION
Working stringified URL

Removal of RETRY PARAMS as they produce error + they don't exist in [TGI test](https://github.com/ritual-net/infernet-monorepo-internal/blob/main/infernet_services/tests/tgi_client_inference_service/conftest.py) 